### PR TITLE
fix: decode block header fields from Core JSON

### DIFF
--- a/bgld.go
+++ b/bgld.go
@@ -112,12 +112,12 @@ type BlockHeader struct {
 	Time              int64
 	Mediantime        int64
 	Nonce             uint32
-	Bits              uint32
+	Bits              string
 	Difficulty        float64
 	Chainwork         string
 	Txes              int    `json:"nTx"`
-	Previousblockhash string `json:"omitempty"`
-	Nextblockhash     string `json:"omitempty"`
+	Previousblockhash string `json:"previousblockhash,omitempty"`
+	Nextblockhash     string `json:"nextblockhash,omitempty"`
 }
 
 func (b *Bgld) GetBlockheader(blockHash string) (*BlockHeader, error) {

--- a/blockheader_json_test.go
+++ b/blockheader_json_test.go
@@ -1,0 +1,42 @@
+package bgld
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGetBlockheaderDecodesBitgesellCoreResponse(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"result":{"hash":"0000000000000000000000000000000000000000000000000000000000000001","confirmations":2,"height":1,"version":536870912,"versionHex":"20000000","merkleroot":"4d5e6f","time":1700000000,"mediantime":1700000000,"nonce":42,"bits":"1d00ffff","difficulty":1,"chainwork":"0000000000000000000000000000000000000000000000000000000000000002","nTx":1,"previousblockhash":"0000000000000000000000000000000000000000000000000000000000000000","nextblockhash":"0000000000000000000000000000000000000000000000000000000000000002"},"error":null,"id":1}`)
+	})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	parts := strings.Split(ts.URL, ":")
+	port, err := strconv.Atoi(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := New(parts[1][2:], port, "user", "pass", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header, err := client.GetBlockheader("0000000000000000000000000000000000000000000000000000000000000001")
+	if err != nil {
+		t.Fatalf("GetBlockheader returned error: %v", err)
+	}
+	if header.Bits != "1d00ffff" {
+		t.Fatalf("Bits = %q, want %q", header.Bits, "1d00ffff")
+	}
+	if header.Previousblockhash != "0000000000000000000000000000000000000000000000000000000000000000" {
+		t.Fatalf("Previousblockhash was not decoded: %q", header.Previousblockhash)
+	}
+	if header.Nextblockhash != "0000000000000000000000000000000000000000000000000000000000000002" {
+		t.Fatalf("Nextblockhash was not decoded: %q", header.Nextblockhash)
+	}
+}

--- a/blockheader_json_test.go
+++ b/blockheader_json_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
-	"strings"
 	"testing"
 )
 
@@ -16,12 +16,15 @@ func TestGetBlockheaderDecodesBitgesellCoreResponse(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	parts := strings.Split(ts.URL, ":")
-	port, err := strconv.Atoi(parts[2])
+	serverURL, err := url.Parse(ts.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, err := New(parts[1][2:], port, "user", "pass", false)
+	port, err := strconv.Atoi(serverURL.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := New(serverURL.Hostname(), port, "user", "pass", false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- Decode Bitgesell Core `getblockheader` `bits` as the compact hex string returned by the RPC API.
- Fix `previousblockhash` / `nextblockhash` JSON tags so lower-case Core response keys populate the struct.
- Add an httptest regression covering a Core-shaped `getblockheader` response.
- Harden the regression test's server URL parsing with `net/url` instead of brittle string splitting.

## Compatibility note
`BlockHeader.Bits` intentionally changes from `uint32` to `string`. Bitgesell/Bitcoin Core RPC returns `bits` as a compact target hex string such as `"1d00ffff"`, and this also matches the existing `Block.Bits string` shape in this package.

## Validation
- RED on upstream shape with the new regression: `go test ./...` fails before the fix because `BlockHeader.Bits` is `uint32` while Core returns `"1d00ffff"`.
- GREEN after fix: `go test ./...` passes.
- Revalidated after test hardening: `go version` => `go1.22.2 linux/amd64`; `go test ./...` passes; `git diff --check` clean.

## Bounty context
Submitted for the Bitgesell improvement PR bounty:
- https://github.com/BitgesellOfficial/bitgesell/issues/81
- https://github.com/BitgesellOfficial/bitgesell/issues/39

Payout rail if approved: USDT/EVM-compatible `0x4a76c7E64C08cF29B59eFC640b4ada97A270d428`.
