### PR TITLE
Cancel RPC requests when timeout expires

### DIFF
--- a/rpcClient.go
+++ b/rpcClient.go
@@ -2,6 +2,7 @@ package bgld
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -77,29 +78,11 @@ func newClient(host string, port int, user, passwd string, useSSL bool, timeout 
 	return
 }
 
-// doTimeoutRequest process a HTTP request with timeout
-func (c *rpcClient) doTimeoutRequest(timer *time.Timer, req *http.Request) (*http.Response, error) {
-	type result struct {
-		resp *http.Response
-		err  error
-	}
-	done := make(chan result, 1)
-	go func() {
-		resp, err := c.httpClient.Do(req)
-		done <- result{resp, err}
-	}()
-	// Wait for the read or the timeout
-	select {
-	case r := <-done:
-		return r.resp, r.err
-	case <-timer.C:
-		return nil, errors.New("Timeout reading data from server")
-	}
-}
-
 // call prepare & exec the request
 func (c *rpcClient) call(method string, params interface{}) (rr rpcResponse, err error) {
-	connectTimer := time.NewTimer(time.Duration(c.timeout) * time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(c.timeout)*time.Second)
+	defer cancel()
+
 	rpcR := rpcRequest{method, params, time.Now().UnixNano(), "1.0"}
 	payloadBuffer := &bytes.Buffer{}
 	jsonEncoder := json.NewEncoder(payloadBuffer)
@@ -107,7 +90,7 @@ func (c *rpcClient) call(method string, params interface{}) (rr rpcResponse, err
 	if err != nil {
 		return
 	}
-	req, err := http.NewRequest("POST", c.serverAddr, payloadBuffer)
+	req, err := http.NewRequestWithContext(ctx, "POST", c.serverAddr, payloadBuffer)
 	if err != nil {
 		return
 	}
@@ -119,8 +102,11 @@ func (c *rpcClient) call(method string, params interface{}) (rr rpcResponse, err
 		req.SetBasicAuth(c.user, c.passwd)
 	}
 
-	resp, err := c.doTimeoutRequest(connectTimer, req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+			err = errors.New("Timeout reading data from server")
+		}
 		return
 	}
 	defer resp.Body.Close()

--- a/rpcClient_test.go
+++ b/rpcClient_test.go
@@ -47,14 +47,14 @@ var _ = Describe("RpcClient", func() {
 
 		Context("When timeout occured", func() {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				time.Sleep((RPCCLIENT_TIMEOUT + 2) * time.Second)
+				time.Sleep(2 * time.Second)
 				fmt.Fprintln(w, "Hello, client")
 			}))
 			defer ts.Close()
 			p := strings.Split(ts.URL, ":")
 			host := p[1][2:]
 			port, err := strconv.ParseInt(p[2], 10, 64)
-			client, err := newClient(host, int(port), "fake", "fake", false, 30)
+			client, err := newClient(host, int(port), "fake", "fake", false, 1)
 			_, err = client.call("getdifficulty", nil)
 
 			It("timeout err should occured", func() {


### PR DESCRIPTION
Summary:
- Replaces the RPC timeout goroutine with a request context deadline so timed-out calls cancel the underlying HTTP request.
- Preserves the existing public timeout error string.
- Reduces the timeout regression test from the default 30-second wait to a focused 1-second case.

Related bounty or issue:
- BitgesellOfficial/bitgesell#81

What changed:
- `rpcClient.call()` now creates the POST request with `http.NewRequestWithContext`.
- Timeout errors are normalized back to `Timeout reading data from server` for compatibility with existing callers/tests.
- The timeout test still verifies timeout behavior but now runs quickly.

Validation:
- `go test ./...`
- `git diff --check`

Notes:
- This is a focused reliability cleanup for the Bitgesell Go RPC client. Before this change, the caller returned on timeout but the HTTP request goroutine could continue running until the server responded.