### PR TITLE
fix: return getblocktemplate RPC result

### DIFF
--- a/bgld.go
+++ b/bgld.go
@@ -201,6 +201,7 @@ func (b *Bgld) GetBlockTemplate(capabilities []string, mode string) (template st
 	if err = handleError(err, &r); err != nil {
 		return
 	}
+	err = json.Unmarshal(r.Result, &template)
 	return
 }
 

--- a/getblocktemplate_test.go
+++ b/getblocktemplate_test.go
@@ -1,0 +1,28 @@
+package bgld
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+)
+
+func TestGetBlockTemplateReturnsRPCResult(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"result":"template-json","error":null,"id":1}`)
+	})
+	ts, host, port, err := getNewTestServer(handler)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer ts.Close()
+
+	bitcoindClient, _ := New(host, port, "x", "fake", false)
+	template, err := bitcoindClient.GetBlockTemplate([]string{"proposal"}, "template")
+	if err != nil {
+		t.Fatalf("GetBlockTemplate error: %v", err)
+	}
+	if template != "template-json" {
+		t.Fatalf("GetBlockTemplate returned %q, want RPC result", template)
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `GetBlockTemplate` so it returns the `getblocktemplate` RPC result instead of an empty string.
- Add a regression test that uses a local JSON-RPC test server and verifies the returned template value.

## Bug
`GetBlockTemplate` already called `getblocktemplate` and handled RPC errors, but it never unmarshaled `r.Result` into the named `template` return value. Successful calls therefore returned `""` even when the node returned a valid block template.

## Validation
```bash
go test -run TestGetBlockTemplateReturnsRPCResult -count=1 -v
go test ./...
```

Both commands pass locally.

Bounty context: Bitgesell PR bounty / improvement program (BitgesellOfficial/bitgesell#39 and BitgesellOfficial/bitgesell#81).